### PR TITLE
Upgrade to kryo 5, bump all dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,13 +164,13 @@
         <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
-            <version>4.0.2</version>
+            <version>5.3.0</version>
         </dependency>
         <!-- Extra serializers for Kryo -->
         <dependency>
             <groupId>de.javakaffee</groupId>
             <artifactId>kryo-serializers</artifactId>
-            <version>0.42</version>
+            <version>0.45</version>
         </dependency>
         <!-- Trove provides optimized map/set collections for primitive types (int, long, etc.) -->
         <!-- Many of our custom serializers are for Trove collection classes. -->
@@ -184,25 +184,25 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
+            <version>31.0.1-jre</version>
         </dependency>
         <!-- Logging API. -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.36</version>
         </dependency>
         <!-- Logging API implementation. -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.10</version>
         </dependency>
         <!-- Junit is for unit testing. -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
In order to prepare for OTP to move to kryo 5 I'm sending this patch.